### PR TITLE
Add support for template plugins

### DIFF
--- a/example/example_plugin.py
+++ b/example/example_plugin.py
@@ -1,0 +1,27 @@
+import getpass
+import itertools
+
+
+def fooify(value):
+    return "".join(t[1] for t in zip(value, itertools.cycle("foo")))
+
+
+def is_root(user):
+    return user == "root"
+
+
+def current_user():
+    return getpass.getuser()
+
+
+PLUGIN_FILTERS = {
+    "fooify": fooify,
+}
+
+PLUGIN_TESTS = {
+    "root": is_root,
+}
+
+PLUGIN_GLOBALS = {
+    "current_user": current_user,
+}

--- a/example/manifest.yaml
+++ b/example/manifest.yaml
@@ -99,6 +99,10 @@ metadata:
   name: webapp-deployment
   labels:
     app: webapp
+  annotations:
+    deploy_user: !k/expr current_user()
+    deployded_as_root: !k/expr current_user() is root
+    user_foo: !k/expr current_user() | fooify
 spec:
   replicas: 1
   selector:

--- a/example/prod.yaml
+++ b/example/prod.yaml
@@ -10,3 +10,6 @@ context:
   - vars/prod.yaml
   - provider: default
     path: vars/common.yaml
+
+template_plugins:
+  - example_plugin

--- a/src/konverter/yaml.py
+++ b/src/konverter/yaml.py
@@ -13,6 +13,8 @@ from ruamel.yaml.representer import RoundTripRepresenter
 from .template import JinjaEnvironment
 
 if typing.TYPE_CHECKING:
+    import types
+
     from ruamel.yaml.nodes import Node, ScalarNode
     from ruamel.yaml.constructor import Constructor
     from ruamel.yaml.representer import Representer
@@ -101,10 +103,15 @@ class KonvertTemplate(KonvertType):
 
 
 class KonverterYAML(BaseYAML):
-    def __init__(self, app: Konverter):
+    def __init__(
+        self,
+        app: Konverter,
+        plugins: typing.Optional[typing.List[types.ModuleType]] = None,
+    ):
         super().__init__()
+        # FIXME: only pass the context and not the whole app
         self.app = app
-        self.env = JinjaEnvironment(undefined=jinja2.StrictUndefined)
+        self.env = JinjaEnvironment(plugins=plugins, undefined=jinja2.StrictUndefined)
         self.register_type(KonvertExpression)
         self.register_type(KonvertTemplate)
 

--- a/tests/e2e/expect_plugin.yaml
+++ b/tests/e2e/expect_plugin.yaml
@@ -1,0 +1,8 @@
+---
+global: test
+filter: TEST
+test: true
+template: |-
+  test
+  TEST
+  True

--- a/tests/e2e/template_plugin.py
+++ b/tests/e2e/template_plugin.py
@@ -1,0 +1,23 @@
+def template_filter(value):
+    return value.upper()
+
+
+def template_test(value):
+    return value == "test"
+
+
+def template_global():
+    return "test"
+
+
+PLUGIN_FILTERS = {
+    "template_filter": template_filter,
+}
+
+PLUGIN_TESTS = {
+    "template_test": template_test,
+}
+
+PLUGIN_GLOBALS = {
+    "template_global": template_global,
+}

--- a/tests/e2e/templates/plugin.yaml
+++ b/tests/e2e/templates/plugin.yaml
@@ -1,0 +1,7 @@
+global: !k/expr template_global()
+filter: !k/expr template_global() | template_filter
+test: !k/expr template_global() is template_test
+template: !k/template |-
+  {{ template_global() }}
+  {{ template_global() | template_filter }}
+  {{ template_global() is template_test }}

--- a/tests/e2e/test_plugin.yaml
+++ b/tests/e2e/test_plugin.yaml
@@ -1,0 +1,8 @@
+templates:
+  - templates/plugin.yaml
+
+context:
+  - vars/_generic.yaml
+
+template_plugins:
+  - template_plugin


### PR DESCRIPTION
This allows users to define custom Jinja2 globals, tests and filters
that can be used in YAML templates in expressions and inline templates.

Resolves #3