### PR TITLE
Support directories as context path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added support for directories as context path
+
 ## [v0.1.1] - 2020-02-03
 
 - Removed mypy as a runtime dependency ([#1](https://github.com/westphahl/konverter/issues/1))

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The `!k/template` tag supports the full [Jinja2 template syntax](https://jinja.p
 
 ### Context
 
-The `context` key in the config contains a list of files that Konverter loads as variable definitions for rendering templates. In the case of multiple context files contain the same top-level key, the entry from the last listed file wins (in the future we might support merging those contexts).
+The `context` key in the config contains a list of files or directories that Konverter uses for loading variable definitions. Those variables serve as the context (hence the name) when rendering templates. In the case of multiple context files containing the same top-level key, the entry from the last listed file wins (in the future we might support merging those contexts).
 
 This is how a simple context file might look like
 ```yaml
@@ -187,7 +187,8 @@ providers:
     key_path: .konverter-vault
 
 context:
-  - vars/common.yaml
+  - provider: default
+    path: vars/common.yaml
   - provider: default
     path: vars/prod.yaml
 ```

--- a/src/konverter/context.py
+++ b/src/konverter/context.py
@@ -61,5 +61,5 @@ class ContextProvider:
         return self._fernet
 
     def load_context(self, path: pathlib.Path) -> typing.Mapping[str, typing.Any]:
-        with open(self.work_dir / path) as yaml_file:
+        with open(path) as yaml_file:
             return ContextYAML(self).load(yaml_file)

--- a/tests/e2e/expect_context_dir.yaml
+++ b/tests/e2e/expect_context_dir.yaml
@@ -1,0 +1,12 @@
+---
+variable: Hello World!
+VARIABLE: HELLO WORLD!
+b64_variable: SGVsbG8gV29ybGQh
+json_variable: '{"number": 43, "other": "BARFOO"}'
+
+template: |-
+  Hello World!
+
+  43
+
+  Hello context!

--- a/tests/e2e/test_context_dir.yaml
+++ b/tests/e2e/test_context_dir.yaml
@@ -1,0 +1,6 @@
+templates:
+  - templates/contexts.yaml
+
+context:
+  - vars/dir/
+  - vars/_generic.yaml

--- a/tests/e2e/vars/dir/contexts.yaml
+++ b/tests/e2e/vars/dir/contexts.yaml
@@ -1,0 +1,5 @@
+object:
+  number: 43
+  other: BARFOO
+
+barfoo: Hello context!


### PR DESCRIPTION
All found `*.y[a]ml` files will be loaded as context variables.