### PR TITLE
Implement new 'konverter-vault show' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 - Added a `konverter-vault show` command that supports YAML and JSON output
+- Added support for `terraform` output format in `konverter-vault show` command
+  that allows using it as an [external data source in
+  Terraform](https://www.terraform.io/docs/providers/external/data_source.html).
 
 ## [v0.2.0] - 2020-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added a `konverter-vault show` command that supports YAML and JSON output
+
 ## [v0.2.0] - 2020-03-01
 
 - Added support for directories as context path

--- a/README.md
+++ b/README.md
@@ -174,6 +174,40 @@ $ konverter-vault encrypt vars/secret.yaml
 $ konverter-vault decrypt vars/secret.yaml
 ```
 
+In case the decrypted content should be passed to another tool that expects
+YAML or JSON, the `konverter-vault show` command can come in handy:
+
+```shell
+$ konverter-vault show --format=json vars/secret.yaml
+{
+  "credentials": {
+    "user": "root",
+    "password": "secret-password"
+  }
+}
+```
+
+It will decrypt the given file and remove all `!k/(encrypt|vault)` YAML tags.
+Supported output formats are `yaml` (default), `json` or `terraform`.
+
+The `terraform` output format is usefull for using `konverter-vault` as an
+[external data source in
+Terraform](https://www.terraform.io/docs/providers/external/data_source.html)
+
+```hcl
+data "external" "konverter" {
+  program = [
+    "konverter-vault", "show", "--format=terraform", "vars/secrets.yaml"
+  ]
+}
+```
+
+Unfortunately the "[external program
+protocol](https://www.terraform.io/docs/providers/external/data_source.html#external-program-protocol)"
+only allows string values (no lists or objects). All `float`, `int` and `bool`
+values will be converted to strings. Other types will cause an error when
+using this output format.
+
 ### Advanced configuration
 
 The above config file could be rewritten in a more verbose format:

--- a/src/konverter/context.py
+++ b/src/konverter/context.py
@@ -1,49 +1,12 @@
 from __future__ import annotations
 
+import functools
 import pathlib
 import typing
 
 from cryptography.fernet import Fernet
-from ruamel.yaml.nodes import ScalarNode
 
-from .vault import KonvertEncrypt, KonvertVault, key_from_file
-from .yaml import BaseYAML
-
-if typing.TYPE_CHECKING:
-    from ruamel.yaml.constructor import Constructor
-
-
-class KonvertContextVault(KonvertVault):
-    @classmethod
-    def from_yaml(cls, constructor: Constructor, node: ScalarNode, yaml) -> ScalarNode:
-        value = yaml.fernet.decrypt(bytes(node.value, encoding="utf8"))
-        return constructor.construct_scalar(
-            ScalarNode(
-                tag="tag:yaml.org,2002:str",
-                value=str(value, encoding="utf8"),
-                style=node.style,
-            )
-        )
-
-
-class KonvertContextEncrypt(KonvertEncrypt):
-    @classmethod
-    def from_yaml(cls, constructor: Constructor, node: ScalarNode, yaml) -> ScalarNode:
-        return constructor.construct_scalar(
-            ScalarNode(tag="tag:yaml.org,2002:str", value=node.value, style=node.style)
-        )
-
-
-class ContextYAML(BaseYAML):
-    def __init__(self, provider: ContextProvider):
-        super().__init__()
-        self.provider = provider
-        self.register_type(KonvertContextEncrypt)
-        self.register_type(KonvertContextVault)
-
-    @property
-    def fernet(self) -> Fernet:
-        return self.provider.fernet
+from .vault import key_from_file, VaultToPlainYAML
 
 
 class ContextProvider:
@@ -54,7 +17,6 @@ class ContextProvider:
         self.key_path = key_path
         self._fernet: typing.Optional[Fernet] = None
 
-    @property
     def fernet(self) -> Fernet:
         if self._fernet is None:
             self._fernet = Fernet(key_from_file(self.work_dir / self.key_path))
@@ -62,4 +24,8 @@ class ContextProvider:
 
     def load_context(self, path: pathlib.Path) -> typing.Mapping[str, typing.Any]:
         with open(path) as yaml_file:
-            return ContextYAML(self).load(yaml_file)
+            # We don't pass the property directly as this would try to load the
+            # key from file which won't work when no key file is provided.
+            # This is a valid use case e.g. when the context doesn't use
+            # encrypted values.
+            return VaultToPlainYAML(functools.partial(self.fernet)).load(yaml_file)

--- a/src/konverter/vault.py
+++ b/src/konverter/vault.py
@@ -218,13 +218,24 @@ def edit(ctx: click.Context, file_path: str):
                 )
 
 
+def to_terraform_format(data: dict) -> dict:
+    def _convert(v):
+        if isinstance(v, str):
+            return v
+        if isinstance(v, (float, int, bool)):
+            return str(v)
+        raise TypeError("Terraform JSON output only supports string values")
+
+    return {k: _convert(v) for k, v in data.items() if v is not None}
+
+
 @cli.command()
 @click.argument("file_path", type=click.Path(exists=True, dir_okay=False))
 @click.option(
     "-f",
     "--format",
     "output_format",
-    type=click.Choice(["yaml", "json"], case_sensitive=False),
+    type=click.Choice(["yaml", "json", "terraform"], case_sensitive=False),
     default="yaml",
 )
 @click.pass_context
@@ -237,6 +248,8 @@ def show(ctx: click.Context, file_path: str, output_format: str):
             data = encrypt_yaml.load(yaml_file)
             if output_format == "json":
                 json.dump(data, stdout, indent=2)
+            elif output_format == "terraform":
+                json.dump(to_terraform_format(data), stdout, indent=2)
             else:
                 encrypt_yaml.dump(data, stdout)
 

--- a/src/konverter/vault.py
+++ b/src/konverter/vault.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import pathlib
 import shutil
 import tempfile
@@ -215,6 +216,29 @@ def edit(ctx: click.Context, file_path: str):
                     err=True,
                     abort=True,
                 )
+
+
+@cli.command()
+@click.argument("file_path", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "-f",
+    "--format",
+    "output_format",
+    type=click.Choice(["yaml", "json"], case_sensitive=False),
+    default="yaml",
+)
+@click.pass_context
+def show(ctx: click.Context, file_path: str, output_format: str):
+    fernet = ctx.obj["fernet"]
+
+    encrypt_yaml = VaultToPlainYAML(fernet)
+    with open(file_path, "r+") as yaml_file:
+        with click.open_file("-", "wt") as stdout:
+            data = encrypt_yaml.load(yaml_file)
+            if output_format == "json":
+                json.dump(data, stdout, indent=2)
+            else:
+                encrypt_yaml.dump(data, stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The new 'konverter-vault show' command supports YAML, JSON and Terraform as
output format.

With the terraform output format the 'konverter-vault show' command can be
used as an external data source in Terraform.